### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "springs"
-version = "1.12.3"
+version = "1.13.0"
 description = """\
     A set of utilities to create and manage typed configuration files \
     effectively, built on top of OmegaConf.\

--- a/src/springs/__init__.py
+++ b/src/springs/__init__.py
@@ -33,8 +33,6 @@ from .shortcuts import (
     debug_logger,
     fdict,
     flist,
-    fobj,
-    fval,
     get_nickname,
     make_flexy,
     make_target,
@@ -49,7 +47,6 @@ from .utils import get_version
 __version__ = get_version()
 
 __all__ = [
-    "add_help",
     "all_resolvers",
     "cast",
     "cli",
@@ -63,8 +60,6 @@ __all__ = [
     "field",
     "flexyclass",
     "flist",
-    "fobj",
-    "fval",
     "from_dataclass",
     "from_dict",
     "from_file",

--- a/src/springs/commandline.py
+++ b/src/springs/commandline.py
@@ -91,6 +91,9 @@ class Flag:
 
     def __str__(self) -> str:
         return f"{self.short}/{self.long}"
+    
+    def __hash__(self) -> int:
+        return hash(str(self))
 
 
 @dataclass

--- a/src/springs/commandline.py
+++ b/src/springs/commandline.py
@@ -91,7 +91,7 @@ class Flag:
 
     def __str__(self) -> str:
         return f"{self.short}/{self.long}"
-    
+
     def __hash__(self) -> int:
         return hash(str(self))
 

--- a/src/springs/commandline.py
+++ b/src/springs/commandline.py
@@ -30,6 +30,7 @@ from .core import (
     to_yaml,
     unsafe_merge,
 )
+from .field_utils import field
 from .flexyclasses import is_flexyclass
 from .logging import configure_logging
 from .nicknames import NicknameRegistry
@@ -94,13 +95,14 @@ class Flag:
     def __str__(self) -> str:
         return f"{self.short}/{self.long}"
 
-    def __hash__(self) -> int:
-        return hash(str(self))
+    @classmethod
+    def field(cls, *args, **kwargs) -> "Flag":
+        return field(default_factory=lambda: cls(*args, **kwargs))
 
 
 @dataclass
 class CliFlags:
-    config: Flag = Flag(
+    config: Flag = Flag.field(
         name="config",
         help=(
             "either a path to a YAML file containing a configuration, or "
@@ -112,22 +114,22 @@ class CliFlags:
         action="append",
         metavar="/path/to/config.yaml",
     )
-    options: Flag = Flag(
+    options: Flag = Flag.field(
         name="options",
         help="print all default options and CLI flags.",
         action="store_true",
     )
-    inputs: Flag = Flag(
+    inputs: Flag = Flag.field(
         name="inputs",
         help="print the input configuration.",
         action="store_true",
     )
-    parsed: Flag = Flag(
+    parsed: Flag = Flag.field(
         name="parsed",
         help="print the parsed configuration.",
         action="store_true",
     )
-    log_level: Flag = Flag(
+    log_level: Flag = Flag.field(
         name="log-level",
         help=(
             "logging level to use for this program; can be one of "
@@ -136,17 +138,17 @@ class CliFlags:
         default="WARNING",
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
     )
-    debug: Flag = Flag(
+    debug: Flag = Flag.field(
         name="debug",
         help="enable debug mode; equivalent to '--log-level DEBUG'",
         action="store_true",
     )
-    quiet: Flag = Flag(
+    quiet: Flag = Flag.field(
         name="quiet",
         help="if provided, it does not print the configuration when running",
         action="store_true",
     )
-    resolvers: Flag = Flag(
+    resolvers: Flag = Flag.field(
         name="resolvers",
         help=(
             "print all registered resolvers in OmegaConf, "
@@ -154,12 +156,12 @@ class CliFlags:
         ),
         action="store_true",
     )
-    nicknames: Flag = Flag(
+    nicknames: Flag = Flag.field(
         name="nicknames",
         help="print all registered nicknames in Springs",
         action="store_true",
     )
-    save: Flag = Flag(
+    save: Flag = Flag.field(
         name="save",
         help="save the configuration to a YAML file and exit",
         default=None,

--- a/src/springs/rich_utils.py
+++ b/src/springs/rich_utils.py
@@ -2,7 +2,17 @@ import os
 import re
 from argparse import SUPPRESS, ArgumentParser
 from dataclasses import dataclass
-from typing import IO, Any, Dict, Generator, List, Optional, Sequence, Union
+from typing import (
+    IO,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from omegaconf import DictConfig, ListConfig
 from rich import box
@@ -153,7 +163,7 @@ class RichArgumentParser(ArgumentParser):
             for ag in self._action_groups:
                 for act in ag._group_actions:
                     if isinstance(act.metavar, str):
-                        metavar = (act.metavar,)
+                        metavar: Tuple[str, ...] = (act.metavar,)
                     elif act.metavar is None:
                         metavar = (act.dest.upper(),)
                     else:

--- a/src/springs/shortcuts.py
+++ b/src/springs/shortcuts.py
@@ -73,37 +73,14 @@ def make_flexy(cls_: Any) -> Any:
     return flexyclass(cls_)
 
 
-def fval(value: T, **kwargs) -> T:
-    """Shortcut for creating a Field with a default value.
-
-    Args:
-        value: value returned by default factory"""
-
-    return field(default=value, **kwargs)
-
-
-def fobj(object: T, **kwargs) -> T:
-    """Shortcut for creating a Field with a default_factory that returns
-    a specific object.
-
-    Args:
-        obj: object returned by default factory"""
-
-    def _factory_fn() -> T:
-        # make a copy so that the same object isn't returned
-        # (it's a factory, not a singleton!)
-        return copy.deepcopy(object)
-
-    return field(default_factory=_factory_fn, **kwargs)
-
-
 def fdict(**kwargs: Any) -> Dict[str, Any]:
     """Shortcut for creating a Field with a default_factory that returns
     a dictionary.
 
     Args:
         **kwargs: values for the dictionary returned by default factory"""
-    return fobj(kwargs)
+    kwargs = copy.deepcopy(kwargs)
+    return field(default_factory=lambda: kwargs)
 
 
 def flist(*args: Any) -> List[Any]:
@@ -112,7 +89,8 @@ def flist(*args: Any) -> List[Any]:
 
     Args:
         *args: values for the list returned by default factory"""
-    return fobj(list(args))
+    l_args = list(copy.deepcopy(args))
+    return field(default_factory=lambda: l_args)
 
 
 def debug_logger(*args: Any, **kwargs: Any) -> Logger:

--- a/tests/fixtures/full_config/config.py
+++ b/tests/fixtures/full_config/config.py
@@ -50,7 +50,7 @@ class DataConfig:
     test_splits_config: List[DataSplitConfig] = sp.field(default_factory=list)
 
 
-@sp.dataclass
+@sp.dataclass(unsafe_hash=True)
 class EnvironmentConfig:
     root_dir: Optional[str] = "~/plruns"
     run_name: Optional[str] = "sse"
@@ -58,7 +58,7 @@ class EnvironmentConfig:
     seed: int = 5663
 
 
-@sp.dataclass
+@sp.dataclass(unsafe_hash=True)
 class ModelConfig:
     _target_: str = "sse.models.TokenClassificationModule"
     tokenizer: HuggingFaceModuleConfig = HuggingFaceModuleConfig(
@@ -98,7 +98,7 @@ class TextLoggerConfig:
     version: str = ""
 
 
-@sp.dataclass
+@sp.dataclass(unsafe_hash=True)
 class LoggersConfig:
     graphic: GraphicLoggerConfig = GraphicLoggerConfig()
     text: TextLoggerConfig = TextLoggerConfig()
@@ -140,6 +140,11 @@ class SseConfig:
     checkpoint: Optional[str] = None
 
     # this controls training environment and data
+    # env: EnvironmentConfig = sp.fobj(EnvironmentConfig())
+    # data: DataConfig = sp.fobj(DataConfig(), help="Data configuration")
+    # model: ModelConfig = sp.fobj(ModelConfig())
+    # loggers: LoggersConfig = sp.fobj(LoggersConfig())
+    # trainer: TrainerConfig = sp.fobj(TrainerConfig())
     env: EnvironmentConfig = EnvironmentConfig()
     data: DataConfig = sp.fobj(DataConfig(), help="Data configuration")
     model: ModelConfig = ModelConfig()

--- a/tests/fixtures/full_config/config.py
+++ b/tests/fixtures/full_config/config.py
@@ -1,9 +1,13 @@
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import springs as sp
 
 PL = "pytorch_lightning"
+
+
+@sp.dataclass
+class SpringsConfig:
+    foo: int = 1
 
 
 @sp.flexyclass
@@ -20,7 +24,6 @@ class LoaderConfig:
 
 
 @sp.flexyclass
-@dataclass
 class HuggingFaceModuleConfig:
     _target_: str = sp.MISSING
     pretrained_model_name_or_path: str = "${backbone}"
@@ -33,7 +36,7 @@ class MapperConfig:
 
 @sp.dataclass
 class DataSplitConfig:
-    loader: LoaderConfig = LoaderConfig()
+    loader: LoaderConfig = sp.field(default_factory=LoaderConfig)
     mappers: List[MapperConfig] = sp.field(default_factory=list)
 
 
@@ -44,13 +47,13 @@ class DataConfig:
     num_workers: int = 0
     pin_memory: bool = False
     persistent_workers: bool = False
-    collator: TargetConfig = TargetConfig()
+    collator: TargetConfig = sp.field(default_factory=TargetConfig)
     train_splits_config: List[DataSplitConfig] = sp.field(default_factory=list)
     valid_splits_config: List[DataSplitConfig] = sp.field(default_factory=list)
     test_splits_config: List[DataSplitConfig] = sp.field(default_factory=list)
 
 
-@sp.dataclass(unsafe_hash=True)
+@sp.dataclass
 class EnvironmentConfig:
     root_dir: Optional[str] = "~/plruns"
     run_name: Optional[str] = "sse"
@@ -58,15 +61,21 @@ class EnvironmentConfig:
     seed: int = 5663
 
 
-@sp.dataclass(unsafe_hash=True)
+@sp.dataclass
 class ModelConfig:
     _target_: str = "sse.models.TokenClassificationModule"
-    tokenizer: HuggingFaceModuleConfig = HuggingFaceModuleConfig(
-        _target_="transformers.AutoTokenizer.from_pretrained"
+    tokenizer: HuggingFaceModuleConfig = sp.field(
+        default_factory=lambda: HuggingFaceModuleConfig(
+            _target_="transformers.AutoTokenizer.from_pretrained"
+        )
     )
-    transformer: HuggingFaceModuleConfig = HuggingFaceModuleConfig(
-        _target_=(
-            "transformers.AutoModelForSequenceClassification.from_pretrained"
+    transformer: HuggingFaceModuleConfig = sp.field(
+        default_factory=lambda: HuggingFaceModuleConfig(
+            _target_=(
+                "transformers."
+                "AutoModelForSequenceClassification."
+                "from_pretrained"
+            )
         )
     )
     val_loss_label: str = "val_loss"
@@ -98,10 +107,12 @@ class TextLoggerConfig:
     version: str = ""
 
 
-@sp.dataclass(unsafe_hash=True)
+@sp.dataclass
 class LoggersConfig:
-    graphic: GraphicLoggerConfig = GraphicLoggerConfig()
-    text: TextLoggerConfig = TextLoggerConfig()
+    graphic: GraphicLoggerConfig = sp.field(
+        default_factory=GraphicLoggerConfig
+    )
+    text: TextLoggerConfig = sp.field(default_factory=TextLoggerConfig)
 
 
 @sp.flexyclass
@@ -134,23 +145,19 @@ class TrainerConfig:
 @sp.dataclass
 class SseConfig:
     # base strings to control where models and tokenizers come from
-    backbone: Optional[str] = sp.fobj(
-        None, help="name of the transformers model to use"
+    backbone: Optional[str] = sp.field(
+        default=None, help="name of the transformers model to use"
     )
     checkpoint: Optional[str] = None
 
-    # this controls training environment and data
-    # env: EnvironmentConfig = sp.fobj(EnvironmentConfig())
-    # data: DataConfig = sp.fobj(DataConfig(), help="Data configuration")
-    # model: ModelConfig = sp.fobj(ModelConfig())
-    # loggers: LoggersConfig = sp.fobj(LoggersConfig())
-    # trainer: TrainerConfig = sp.fobj(TrainerConfig())
-    env: EnvironmentConfig = EnvironmentConfig()
-    data: DataConfig = sp.fobj(DataConfig(), help="Data configuration")
-    model: ModelConfig = ModelConfig()
-    loggers: LoggersConfig = LoggersConfig()
-    trainer: TrainerConfig = TrainerConfig()
-    checkpointing: Optional[CheckpointConfig] = sp.fval(
-        None, help="optional configurations to deal with checkpointing"
+    env: EnvironmentConfig = sp.field(default_factory=EnvironmentConfig)
+    data: DataConfig = sp.field(
+        default_factory=DataConfig, help="Data configuration"
+    )
+    model: ModelConfig = sp.field(default_factory=ModelConfig)
+    loggers: LoggersConfig = sp.field(default_factory=LoggersConfig)
+    trainer: TrainerConfig = sp.field(default_factory=TrainerConfig)
+    checkpointing: Optional[CheckpointConfig] = sp.field(
+        default=None, help="optional configurations to deal with checkpointing"
     )
     early_stopping: Optional[EarlyStoppingConfig] = None

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -11,6 +11,9 @@ class DT:
     foo: str = "bar"
 
 
+DT(foo="bar")
+
+
 class TestCreation(unittest.TestCase):
     def test_from_dict(self):
         self.assertEqual(

--- a/tests/test_flexyclass.py
+++ b/tests/test_flexyclass.py
@@ -1,36 +1,35 @@
 import unittest
-from dataclasses import dataclass
 
-from springs import MISSING, from_dataclass, from_dict, make_target
-from springs.flexyclasses import flexyclass
+import springs as sp
 
 
-@flexyclass
-@dataclass
+@sp.flexyclass
 class FlexyConfig:
-    a: int = MISSING
+    a: int = sp.MISSING
 
 
-@dataclass
+@sp.dataclass
 class FlexyConfigContainer:
-    f1: FlexyConfig = FlexyConfig(a=1)
-    f2: FlexyConfig = FlexyConfig(a=1, b=2)  # type: ignore
+    f1: FlexyConfig = sp.field(default_factory=lambda: FlexyConfig(a=1))
+    f2: FlexyConfig = sp.field(
+        default_factory=lambda: FlexyConfig(a=1, b=2)  # type: ignore
+    )
 
 
-@flexyclass
+@sp.flexyclass
 class PipelineStepConfig:
-    _target_: str = MISSING
+    _target_: str = sp.MISSING
 
 
 class TestFlexyClass(unittest.TestCase):
     def test_flexyclass(self):
         di = {"a": 1, "b": 2}
-        config = from_dict({"_target_": make_target(FlexyConfig), **di})
+        config = sp.from_dict({"_target_": sp.make_target(FlexyConfig), **di})
         self.assertEqual(config.a, di["a"])
         self.assertEqual(config.b, di["b"])
 
     def test_flexyclass_container(self):
-        config = from_dataclass(FlexyConfigContainer)
+        config = sp.from_dataclass(FlexyConfigContainer)
         self.assertTrue(
             hasattr(config.f2, "b"), "FlexyConfigContainer.f1.b is not set"
         )

--- a/tests/test_nested_init.py
+++ b/tests/test_nested_init.py
@@ -15,13 +15,13 @@ class Outer:
         self.b = b
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class InnerConfig:
     _target_: str = Target.to_string(Inner)
     a: int = 1
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class OuterConfig:
     _target_: str = Target.to_string(Outer)
     a: InnerConfig = InnerConfig()

--- a/tests/test_nested_init.py
+++ b/tests/test_nested_init.py
@@ -1,7 +1,7 @@
 import unittest
 from dataclasses import dataclass
 
-from springs.initialize import Target, init
+import springs as sp
 
 
 class Inner:
@@ -15,23 +15,23 @@ class Outer:
         self.b = b
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class InnerConfig:
-    _target_: str = Target.to_string(Inner)
+    _target_: str = sp.Target.to_string(Inner)
     a: int = 1
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class OuterConfig:
-    _target_: str = Target.to_string(Outer)
-    a: InnerConfig = InnerConfig()
+    _target_: str = sp.Target.to_string(Outer)
+    a: InnerConfig = sp.field(default_factory=InnerConfig)
     b: int = 2
 
 
 class TestInit(unittest.TestCase):
     def test_nested_init(self):
         config = OuterConfig()
-        out = init.now(config, Outer)
+        out = sp.init.now(config, Outer)
 
         self.assertTrue(isinstance(out, Outer))
         self.assertTrue(isinstance(out.a, Inner))

--- a/tests/test_new_merge.py
+++ b/tests/test_new_merge.py
@@ -7,8 +7,8 @@ from omegaconf import OmegaConf
 
 from springs import DictConfig
 from springs.core import merge
-from springs.flexyclasses import FlexyClass
 from springs.field_utils import field
+from springs.flexyclasses import FlexyClass
 
 
 @FlexyClass.flexyclass

--- a/tests/test_new_merge.py
+++ b/tests/test_new_merge.py
@@ -1,6 +1,6 @@
 import pickle
 import unittest
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from omegaconf import OmegaConf
@@ -8,6 +8,7 @@ from omegaconf import OmegaConf
 from springs import DictConfig
 from springs.core import merge
 from springs.flexyclasses import FlexyClass
+from springs.field_utils import field
 
 
 @FlexyClass.flexyclass
@@ -16,10 +17,9 @@ class ObjNestedConfig:
 
 
 @FlexyClass.flexyclass
-@dataclass
 class ObjConfig:
     _target_: str = "springs.core"
-    nest: ObjNestedConfig = ObjNestedConfig()
+    nest: ObjNestedConfig = field(default_factory=ObjNestedConfig)
 
 
 @dataclass
@@ -33,7 +33,7 @@ class AppCfg:
     elsewhere: Optional[Any] = None
     foo: FooCfg = field(default_factory=FooCfg)
     bar: bool = False
-    c: ObjConfig = ObjConfig()
+    c: ObjConfig = field(default_factory=ObjConfig)
     cn: Dict[str, ObjConfig] = field(default_factory=dict)
 
 

--- a/tests/test_nicknames.py
+++ b/tests/test_nicknames.py
@@ -17,7 +17,9 @@ class DataConfig:
 @sp.nickname("dev_config")
 @sp.dataclass
 class DevConfig:
-    data: DataConfig = sp.field(default_factory=lambda: DataConfig(path="/dev"))
+    data: DataConfig = sp.field(
+        default_factory=lambda: DataConfig(path="/dev")
+    )
     name: str = "dev"
     batch_size: int = 32
 

--- a/tests/test_nicknames.py
+++ b/tests/test_nicknames.py
@@ -9,7 +9,7 @@ from omegaconf import DictConfig
 import springs as sp
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class DataConfig:
     path: str = sp.MISSING
 

--- a/tests/test_nicknames.py
+++ b/tests/test_nicknames.py
@@ -9,7 +9,7 @@ from omegaconf import DictConfig
 import springs as sp
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class DataConfig:
     path: str = sp.MISSING
 
@@ -17,7 +17,7 @@ class DataConfig:
 @sp.nickname("dev_config")
 @sp.dataclass
 class DevConfig:
-    data: DataConfig = DataConfig(path="/dev")
+    data: DataConfig = sp.field(default_factory=lambda: DataConfig(path="/dev"))
     name: str = "dev"
     batch_size: int = 32
 

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -20,4 +20,4 @@ class TestResolvers(unittest.TestCase):
         self.assertEqual(c.c, "___fooo___")
         self.assertEqual(c.d, c.b)
         self.assertEqual(c.e, "_f")
-        self.assertEqual(c.f, " fooo")
+        self.assertEqual(c.f, "fooo")

--- a/tests/test_resolvers_in_nested.py
+++ b/tests/test_resolvers_in_nested.py
@@ -7,14 +7,14 @@ from omegaconf.errors import ValidationError
 import springs as sp
 
 
-@sp.dataclass(unsafe_hash=True)
+@sp.dataclass
 class NestedConfig:
     value: int = 0
 
 
 @sp.dataclass
 class Config:
-    nested: NestedConfig = NestedConfig()
+    nested: NestedConfig = sp.field(default_factory=NestedConfig)
     li: List[NestedConfig] = sp.field(default_factory=list)
     di: Dict[str, NestedConfig] = sp.field(default_factory=dict)
 

--- a/tests/test_resolvers_in_nested.py
+++ b/tests/test_resolvers_in_nested.py
@@ -7,7 +7,7 @@ from omegaconf.errors import ValidationError
 import springs as sp
 
 
-@sp.dataclass
+@sp.dataclass(unsafe_hash=True)
 class NestedConfig:
     value: int = 0
 


### PR DESCRIPTION
This PR addresses an [update to the `dataclasses` module in python 3.11](https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses), which prevents adding mutable fields to dataclasses by default. There were a few places where this appears.

First, the `springs.cli.Flag` dataclass. This change was addressed by implementing a `__hash__` method.

Second, in the configs in `tests/fixtures/configs`. Here, the PR makes dataclasses hashable by passing `unsafe_hash=True` to the `dataclass` wrapper function.

There are other approaches to this outlined [here](https://github.com/python/cpython/issues/99401#issuecomment-1312213496):
 - using `default_factory` instead of directly instantiating the. This led to an error within omegaconf: `Dict[Any, Any] cannot be assigned type Field`. (or something like that)
 - using the `sp.fobj` method to wrap the . This led to an omegaconf error `cannot pickle 'mappingproxy' object` (might be related to deepcopying a dataclass)
 - explicitly defining `__hash__` methods on all of the configs in `tests/fixtures/configs`. This seemed like too much work compared to just using `unsafe_hash=True`.